### PR TITLE
Fix the color of text in filter popups

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -206,6 +206,14 @@ span.checkmark {
     }
 }
 
+.rm-reference-container .bp3-button {
+    color: #182026 !important;
+}
+
+.rm-reference-container .bp3-popover-content .flex-h-box div > div > span {
+    color: #202b33 !important;
+}
+
 .CodeMirror {
     font-size: 13px !important;
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -11,50 +11,62 @@
   --popup-background-color: #ffffff;
   --reference-item-background: hsl(0, 0%, 99%);
   --brackets-color: rgba(0, 0, 0, 0.25);
-  --empty-text-color: hsl(203, 12%, 75%); }
+  --empty-text-color: hsl(203, 12%, 75%);
+}
 
 body,
 .roam-body,
 .roam-app,
 .rm-pages-title-text,
 .bp3-button {
-  color: var(--font-color) !important; }
+  color: var(--font-color) !important;
+}
 
 h1 {
-  color: var(--font-color) !important; }
+  color: var(--font-color) !important;
+}
 
 .rm-page-ref-link-color {
-  color: var(--link-color) !important; }
+  color: var(--link-color) !important;
+}
 
 .rm-page-ref-brackets {
-  color: var(--brackets-color) !important; }
+  color: var(--brackets-color) !important;
+}
 
 .bp3-input {
-  background: var(--body-background-color) !important; }
-  .bp3-input::placeholder {
-    color: var(--font-color-placeholder) !important; }
+  background: var(--body-background-color) !important;
+}
+.bp3-input::placeholder {
+  color: var(--font-color-placeholder) !important;
+}
 
 .bp3-elevation-3,
 .confirmation-content-dialog,
 .bp3-dialog {
-  background: var(--popup-background-color) !important; }
+  background: var(--popup-background-color) !important;
+}
 
 .rm-title-untitled,
 #block-input-ghost > span,
 textarea::placeholder {
-  color: var(--empty-text-color) !important; }
+  color: var(--empty-text-color) !important;
+}
 
 .rm-all-pages .table .rm-pages-row.rm-pages-row-header {
-  background: var(--main-background-color) !important; }
+  background: var(--main-background-color) !important;
+}
 
 body,
 div,
 textarea,
 .level2 {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif !important; }
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif !important;
+}
 
 iframe {
-  border: none !important; }
+  border: none !important;
+}
 
 .loading-astrolabe {
   position: absolute !important;
@@ -62,14 +74,17 @@ iframe {
   height: 80px !important;
   opacity: 0.3 !important;
   top: calc(50% - 40px) !important;
-  left: calc(50% - 40px) !important; }
+  left: calc(50% - 40px) !important;
+}
 
 #roam-sidebar-logo {
-  display: none !important; }
+  display: none !important;
+}
 
 body,
 #app {
-  background: var(--main-background-color) !important; }
+  background: var(--main-background-color) !important;
+}
 
 .roam-center {
   border-left: 1px solid var(--border-color) !important;
@@ -80,173 +95,205 @@ body,
   overflow: visible !important;
   background: var(--body-background-color) !important;
   margin-right: 12px;
-  margin-left: 12px; }
+  margin-left: 12px;
+}
 
 .roam-topbar {
   background: var(--main-background-color) !important;
-  border-bottom: none !important; }
-  .roam-topbar input#find-or-create-input {
-    box-shadow: none !important;
-    border: 1px solid var(--border-color) !important; }
+  border-bottom: none !important;
+}
+.roam-topbar input#find-or-create-input {
+  box-shadow: none !important;
+  border: 1px solid var(--border-color) !important;
+}
 
 .roam-body,
 .roam-topbar,
 #right-sidebar,
 .roam-sidebar-container {
-  background: var(--main-background-color) !important; }
+  background: var(--main-background-color) !important;
+}
 
 #right-sidebar {
   border: none !important;
   transition: none !important;
-  overflow: hidden !important; }
-  #right-sidebar h1 {
-    font-size: 18px !important; }
-  #right-sidebar #roam-right-sidebar-content > div[style] {
-    border-bottom: 1px solid var(--subtle-border-color) !important; }
-  #right-sidebar .hoverparent,
-  #right-sidebar .react-resizable {
-    max-width: 100% !important; }
-    #right-sidebar .hoverparent img,
-    #right-sidebar .react-resizable img {
-      max-width: 100% !important; }
+  overflow: hidden !important;
+}
+#right-sidebar h1 {
+  font-size: 18px !important;
+}
+#right-sidebar #roam-right-sidebar-content > div[style] {
+  border-bottom: 1px solid var(--subtle-border-color) !important;
+}
+#right-sidebar .hoverparent,
+#right-sidebar .react-resizable {
+  max-width: 100% !important;
+}
+#right-sidebar .hoverparent img,
+#right-sidebar .react-resizable img {
+  max-width: 100% !important;
+}
 
 .rm-page-ref-tag {
-  color: #9099a1 !important; }
+  color: #9099a1 !important;
+}
 
 span.checkmark {
-  top: -2px; }
+  top: -2px;
+}
 
 .rm-level1 div,
 .rm-level1 textarea {
   font-size: 22px !important;
-  line-height: 1.5 !important; }
+  line-height: 1.5 !important;
+}
 
 .rm-level2 div,
 .rm-level2 textarea {
   font-size: 20px !important;
-  line-height: 1.5 !important; }
+  line-height: 1.5 !important;
+}
 
 .rm-level3 div,
 .rm-level3 textarea {
   font-size: 18px !important;
-  line-height: 1.5 !important; }
+  line-height: 1.5 !important;
+}
 
 .level2 {
-  font-weight: inherit !important; }
+  font-weight: inherit !important;
+}
 
 .roam-log-container .roam-log-page {
-  border-top: 1px solid var(--subtle-border-color) !important; }
-  .roam-log-container .roam-log-page:first-child {
-    min-height: 0 !important;
-    border-top: none !important; }
+  border-top: 1px solid var(--subtle-border-color) !important;
+}
+.roam-log-container .roam-log-page:first-child {
+  min-height: 0 !important;
+  border-top: none !important;
+}
 
 .rm-reference-item {
   background: var(--reference-item-background) !important;
   border: 1px solid var(--subtle-border-color) !important;
   border-radius: 6px !important;
-  padding: 8px 10px 8px 2px !important; }
-  .rm-reference-item .rm-block-text {
-    font-size: var(--font-size) !important; }
+  padding: 8px 10px 8px 2px !important;
+}
+.rm-reference-item .rm-block-text {
+  font-size: var(--font-size) !important;
+}
+
+.rm-reference-container .bp3-button {
+  color: #182026 !important;
+}
+
+.rm-reference-container .bp3-popover-content .flex-h-box div > div > span {
+  color: #202b33 !important;
+}
 
 .CodeMirror {
-  font-size: 13px !important; }
+  font-size: 13px !important;
+}
 
 .roam-body .roam-app .roam-sidebar-container .roam-sidebar-content .log-button:hover,
-.roam-body
-.roam-app
-.roam-sidebar-container
-.roam-sidebar-content
-.starred-pages-wrapper
-.starred-pages
-.page:hover {
+.roam-body .roam-app .roam-sidebar-container .roam-sidebar-content .starred-pages-wrapper .starred-pages .page:hover {
   background-color: transparent !important;
-  color: var(--font-color) !important; }
+  color: var(--font-color) !important;
+}
 
 .roam-body .roam-app .roam-sidebar-container .roam-sidebar-content .log-button,
 .roam-body .roam-app .roam-sidebar-container .roam-sidebar-content .starred-pages-wrapper,
-.roam-body
-.roam-app
-.roam-sidebar-container
-.roam-sidebar-content
-.starred-pages-wrapper
-.starred-pages
-.page,
+.roam-body .roam-app .roam-sidebar-container .roam-sidebar-content .starred-pages-wrapper .starred-pages .page,
 .bp3-minimal > div {
   color: var(--font-color-lighter) !important;
-  font-size: 13px !important; }
+  font-size: 13px !important;
+}
 
 .roam-sidebar-content {
-  padding: 0 !important; }
-  .roam-sidebar-content > div:not(.log-button):not(:first-child) {
-    padding: 0 !important; }
-  .roam-sidebar-content > div:first-child {
-    padding-bottom: 18px !important; }
-  .roam-sidebar-content div {
-    line-height: 1.2 !important; }
-  .roam-sidebar-content .rm-db-title {
-    margin-top: 0 !important;
-    color: var(--font-color-lighter) !important; }
+  padding: 0 !important;
+}
+.roam-sidebar-content > div:not(.log-button):not(:first-child) {
+  padding: 0 !important;
+}
+.roam-sidebar-content > div:first-child {
+  padding-bottom: 18px !important;
+}
+.roam-sidebar-content div {
+  line-height: 1.2 !important;
+}
+.roam-sidebar-content .rm-db-title {
+  margin-top: 0 !important;
+  color: var(--font-color-lighter) !important;
+}
 
 .starred-pages-wrapper > div:first-child {
-  display: none; }
+  display: none;
+}
 .starred-pages-wrapper .flex-h-box,
 .starred-pages-wrapper .flex-h-box span {
   font-size: 13px !important;
-  opacity: 0.6 !important; }
+  opacity: 0.6 !important;
+}
 
 .roam-body .roam-app .roam-sidebar-container .roam-sidebar-content .log-button,
-.roam-body
-.roam-app
-.roam-sidebar-container
-.roam-sidebar-content
-.starred-pages-wrapper
-.starred-pages
-.page {
-  padding: 6px 24px 6px !important; }
+.roam-body .roam-app .roam-sidebar-container .roam-sidebar-content .starred-pages-wrapper .starred-pages .page {
+  padding: 6px 24px 6px !important;
+}
 
 .bp3-icon-small {
-  padding-left: 24px !important; }
+  padding-left: 24px !important;
+}
 
 .rm-block-text {
   max-width: 640px !important;
-  font-size: var(--font-size) !important; }
+  font-size: var(--font-size) !important;
+}
 
 .block-bullet-view {
-  margin-bottom: 3px !important; }
+  margin-bottom: 3px !important;
+}
 
 .roam-article > div > div h1 {
   font-size: 26px !important;
   font-weight: 700 !important;
   height: auto !important;
-  line-height: 1.5 !important; }
+  line-height: 1.5 !important;
+}
 
 .rm-title-display,
 .rm-title-textarea {
   height: auto !important;
-  line-height: 1.5 !important; }
+  line-height: 1.5 !important;
+}
 
 .roam-log-container .roam-log-preview h1 {
   font-size: 22px !important;
-  font-weight: 700 !important; }
+  font-weight: 700 !important;
+}
 
 strong {
-  font-weight: 700 !important; }
+  font-weight: 700 !important;
+}
 
 .block-border-left {
-  border-left-color: var(--subtle-border-color) !important; }
+  border-left-color: var(--subtle-border-color) !important;
+}
 
 .rm-reference-main div > strong {
-  color: gray !important; }
+  color: gray !important;
+}
 
 @media (prefers-color-scheme: dark) {
   body {
-    background: #171717 !important; }
+    background: #171717 !important;
+  }
 
   .roam-highlight {
-    background-color: #453e17 !important; }
+    background-color: #453e17 !important;
+  }
 
   .bp3-overlay-backdrop {
-    background-color: rgba(0, 0, 0, 0.7) !important; }
+    background-color: rgba(0, 0, 0, 0.7) !important;
+  }
 
   :root {
     --font-color: hsl(205, 0%, 98%);
@@ -260,4 +307,6 @@ strong {
     --popup-background-color: hsl(0, 0%, 14%);
     --reference-item-background: hsl(0, 0%, 8%);
     --brackets-color: rgba(255, 255, 255, 0.3);
-    --empty-text-color: hsl(203, 5%, 70%); } }
+    --empty-text-color: hsl(203, 5%, 70%);
+  }
+}


### PR DESCRIPTION
Fixes the overridden text colors in the reference popup.

"Click to Add", "Shift-Click to Add" and reference buttons now use the default Roam Research colors.

I was unable to compile the scss with the recommended command, gave me these errors:
```bash
$ sass --sourcemap=none --no-cache --watch ./main.scss:./src/css/main.css
Could not find an option named "sourcemap".
Could not find an option named "cache".
```
If someone could help me out with this, I can include the compiled css as well.

Closes #7 