### PR TITLE
fix: padding in sidebar icons

### DIFF
--- a/components/style.css
+++ b/components/style.css
@@ -462,7 +462,7 @@ span.checkmark {
   background-color: inherit;
 }
 
-.bp3-icon-small {
+.bp3-icon-star {
   padding-left: 24px !important;
 }
 

--- a/components/style.scss
+++ b/components/style.scss
@@ -493,7 +493,7 @@ span.checkmark {
     }
   }
 }
-.bp3-icon-small {
+.bp3-icon-star {
   padding-left: 24px !important;
 }
 

--- a/dark.css
+++ b/dark.css
@@ -514,7 +514,7 @@ span.checkmark {
   background-color: inherit;
 }
 
-.bp3-icon-small {
+.bp3-icon-star {
   padding-left: 24px !important;
 }
 

--- a/light.css
+++ b/light.css
@@ -485,7 +485,7 @@ span.checkmark {
   background-color: inherit;
 }
 
-.bp3-icon-small {
+.bp3-icon-star {
   padding-left: 24px !important;
 }
 

--- a/main.css
+++ b/main.css
@@ -538,7 +538,7 @@ span.checkmark {
   background-color: inherit;
 }
 
-.bp3-icon-small {
+.bp3-icon-star {
   padding-left: 24px !important;
 }
 


### PR DESCRIPTION
<img width="226" alt="Screen Shot 2021-04-20 at 9 41 55 PM" src="https://user-images.githubusercontent.com/2144783/115489154-55adb500-a221-11eb-8668-8e8213e32e7e.png">

Before / After

<img width="229" alt="Screen Shot 2021-04-20 at 9 42 05 PM" src="https://user-images.githubusercontent.com/2144783/115489159-57777880-a221-11eb-9321-cab6e9ee7d08.png">
