### PR TITLE
Separate font family as a variable

### DIFF
--- a/components/dark-palette.css
+++ b/components/dark-palette.css
@@ -1,4 +1,7 @@
 :root {
+  --font-size: 15.5px;
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+    "Open Sans", "Helvetica Neue", sans-serif;
   --c1: hsl(205, 0%, 98%);
   --c2: hsl(0, 0%, 50%);
   --c3: hsl(206, 15%, 40%);

--- a/components/dark-palette.scss
+++ b/components/dark-palette.scss
@@ -1,4 +1,7 @@
 :root {
+  --font-size: 15.5px;
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+    "Open Sans", "Helvetica Neue", sans-serif;
   --c1: hsl(205, 0%, 98%);
   --c2: hsl(0, 0%, 50%);
   --c3: hsl(206, 15%, 40%);

--- a/components/light-palette.css
+++ b/components/light-palette.css
@@ -1,5 +1,7 @@
 :root {
   --font-size: 15.5px;
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+    "Open Sans", "Helvetica Neue", sans-serif;
   --c1: hsl(206, 10%, 16%);
   --c2: hsl(206, 12%, 40%);
   --c3: hsl(206, 16%, 60%);

--- a/components/light-palette.scss
+++ b/components/light-palette.scss
@@ -1,5 +1,7 @@
 :root {
   --font-size: 15.5px;
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+    "Open Sans", "Helvetica Neue", sans-serif;
   --c1: hsl(206, 10%, 16%);
   --c2: hsl(206, 12%, 40%);
   --c3: hsl(206, 16%, 60%);

--- a/components/style.css
+++ b/components/style.css
@@ -292,7 +292,8 @@ body,
 div,
 textarea,
 .level2 {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif !important;
+  font-family: var(--font-family) !important;
+  font-variation-settings: var(--font-variation-settings);
 }
 
 iframe {

--- a/components/style.css
+++ b/components/style.css
@@ -291,7 +291,9 @@ textarea::placeholder {
 body,
 div,
 textarea,
-.level2 {
+.level2,
+.rm-level2,
+.rm-heading-level-2 > .rm-block__self .rm-block__input {
   font-family: var(--font-family) !important;
   font-variation-settings: var(--font-variation-settings);
 }

--- a/components/style.scss
+++ b/components/style.scss
@@ -298,8 +298,8 @@ body,
 div,
 textarea,
 .level2 {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-    "Open Sans", "Helvetica Neue", sans-serif !important;
+  font-family: var(--font-family) !important;
+  font-variation-settings: var(--font-variation-settings);
 }
 
 iframe {

--- a/components/style.scss
+++ b/components/style.scss
@@ -297,7 +297,9 @@ textarea::placeholder {
 body,
 div,
 textarea,
-.level2 {
+.level2,
+.rm-level2,
+.rm-heading-level-2>.rm-block__self .rm-block__input {
   font-family: var(--font-family) !important;
   font-variation-settings: var(--font-variation-settings);
 }

--- a/dark.css
+++ b/dark.css
@@ -1,4 +1,7 @@
 :root {
+  --font-size: 15.5px;
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+    "Open Sans", "Helvetica Neue", sans-serif;
   --c1: hsl(205, 0%, 98%);
   --c2: hsl(0, 0%, 50%);
   --c3: hsl(206, 15%, 40%);
@@ -344,7 +347,8 @@ body,
 div,
 textarea,
 .level2 {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif !important;
+  font-family: var(--font-family) !important;
+  font-variation-settings: var(--font-variation-settings);
 }
 
 iframe {

--- a/dark.css
+++ b/dark.css
@@ -346,7 +346,9 @@ textarea::placeholder {
 body,
 div,
 textarea,
-.level2 {
+.level2,
+.rm-level2,
+.rm-heading-level-2 > .rm-block__self .rm-block__input {
   font-family: var(--font-family) !important;
   font-variation-settings: var(--font-variation-settings);
 }

--- a/light.css
+++ b/light.css
@@ -316,7 +316,9 @@ textarea::placeholder {
 body,
 div,
 textarea,
-.level2 {
+.level2,
+.rm-level2,
+.rm-heading-level-2 > .rm-block__self .rm-block__input {
   font-family: var(--font-family) !important;
   font-variation-settings: var(--font-variation-settings);
 }

--- a/light.css
+++ b/light.css
@@ -1,5 +1,7 @@
 :root {
   --font-size: 15.5px;
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+    "Open Sans", "Helvetica Neue", sans-serif;
   --c1: hsl(206, 10%, 16%);
   --c2: hsl(206, 12%, 40%);
   --c3: hsl(206, 16%, 60%);
@@ -315,7 +317,8 @@ body,
 div,
 textarea,
 .level2 {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif !important;
+  font-family: var(--font-family) !important;
+  font-variation-settings: var(--font-variation-settings);
 }
 
 iframe {

--- a/main.css
+++ b/main.css
@@ -372,7 +372,9 @@ textarea::placeholder {
 body,
 div,
 textarea,
-.level2 {
+.level2,
+.rm-level2,
+.rm-heading-level-2 > .rm-block__self .rm-block__input {
   font-family: var(--font-family) !important;
   font-variation-settings: var(--font-variation-settings);
 }

--- a/main.css
+++ b/main.css
@@ -1,5 +1,7 @@
 :root {
   --font-size: 15.5px;
+  --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+    "Open Sans", "Helvetica Neue", sans-serif;
   --c1: hsl(206, 10%, 16%);
   --c2: hsl(206, 12%, 40%);
   --c3: hsl(206, 16%, 60%);
@@ -23,6 +25,9 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
+    --font-size: 15.5px;
+    --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+      "Open Sans", "Helvetica Neue", sans-serif;
     --c1: hsl(205, 0%, 98%);
     --c2: hsl(0, 0%, 50%);
     --c3: hsl(206, 15%, 40%);
@@ -368,7 +373,8 @@ body,
 div,
 textarea,
 .level2 {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif !important;
+  font-family: var(--font-family) !important;
+  font-variation-settings: var(--font-variation-settings);
 }
 
 iframe {


### PR DESCRIPTION
Created two new variables `--font-family` and `--font-variation-settings` to allow overriding the font family on an individual basis.

Also added the variable `--font-size` to the dark theme list to ensure the dark.css is generated with the variable set correctly.  Seemed like an oversight, but perhaps there's some fallback I'm unaware of that would set it anyway.

Example of using this to override the font-family...
```
@import url("https://linuz90.github.io/better-roam-research/main.css");

@font-face {
  font-family: "Lexend";
  src: url("https://www.lexend.com/static/fonts/lexendgx.woff2") format("woff2"), url("https://www.lexend.com/static/fonts/lexendgx.ttf") format("truetype");
  font-weight: normal;
  font-style: normal;
  font-optical-sizing: auto;
}

:root {
  --font-family: Lexend, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
  --font-variation-settings: 'LXND' 10;
}
```